### PR TITLE
Add a podspec so that it would correctly copy the ios files

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 import { NativeModules, Platform, PermissionsAndroid } from 'react-native';
 
-const { AddCalendarEvent } = NativeModules;
+const AddCalendarEvent = NativeModules.AddCalendarEvent;
 
 const _presentCalendarEventDialog = eventConfig => {
   return AddCalendarEvent.presentNewEventDialog(eventConfig);

--- a/ios/AddCalendarEvent.podspec
+++ b/ios/AddCalendarEvent.podspec
@@ -6,13 +6,13 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                   AddCalendarEvent
                    DESC
-  s.homepage     = "https://github.com/shrutic/react-native-add-calendar-event"
+  s.homepage     = ""
   s.license      = "MIT"
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "author@domain.cn" }
   s.platform     = :ios, "7.0"
-  s.source       = { :git => "https://github.com/vonovak/react-native-add-calendar-event.git", :tag => "master" }
-  s.source_files  = "ios/*.{h,m}"
+  s.source       = { :git => "https://github.com/author/AddCalendarEvent.git", :tag => "master" }
+  s.source_files  = "AddCalendarEvent/**/*.{h,m}"
   s.requires_arc = true
 
 

--- a/ios/AddCalendarEvent.podspec
+++ b/ios/AddCalendarEvent.podspec
@@ -11,8 +11,8 @@ Pod::Spec.new do |s|
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "author@domain.cn" }
   s.platform     = :ios, "7.0"
-  s.source       = { :git => "https://github.com/author/AddCalendarEvent.git", :tag => "master" }
-  s.source_files  = "AddCalendarEvent/**/*.{h,m}"
+  s.source       = { :git => "https://github.com/vonovak/react-native-add-calendar-event.git", :tag => "master" }
+  s.source_files  = "ios/*.{h,m}"
   s.requires_arc = true
 
 

--- a/ios/AddCalendarEvent.podspec
+++ b/ios/AddCalendarEvent.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                   AddCalendarEvent
                    DESC
-  s.homepage     = ""
+  s.homepage     = "https://github.com/shrutic/react-native-add-calendar-event"
   s.license      = "MIT"
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "author@domain.cn" }

--- a/react-native-add-calendar-event.podspec
+++ b/react-native-add-calendar-event.podspec
@@ -1,0 +1,18 @@
+require 'json'
+package_json = JSON.parse(File.read('package.json'))
+
+Pod::Spec.new do |s|
+  s.name         = 'react-native-add-calendar-event'
+  s.version      = package_json['version']
+  s.summary      = package_json['description']
+  s.homepage     = 'https://github.com/vonovak/react-native-add-calendar-event'
+  s.author       = package_json['author']
+  s.license      = package_json['license']
+  s.platform     = :ios, '8.0'
+  s.source       = {
+    :git => 'https://github.com/vonovak/react-native-add-calendar-event.git'
+  }
+  s.source_files  = '*.{h,m}'
+
+  s.dependency 'React'
+end

--- a/react-native-add-calendar-event.podspec
+++ b/react-native-add-calendar-event.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.source       = {
     :git => 'https://github.com/vonovak/react-native-add-calendar-event.git'
   }
-  s.source_files  = '*.{h,m}'
+  s.source_files  = 'ios/*.{h,m}'
 
   s.dependency 'React'
 end


### PR DESCRIPTION
This podspec correctly copies over the required ios files to the project and can be used as an alternative to manual linking described in README if the ios project is based on Cocoapods ( which is very common these days)