### PR TITLE
Fixes "Unparseable date" and invalid time for Android

### DIFF
--- a/android/src/main/java/com/vonovak/AddCalendarEventModule.java
+++ b/android/src/main/java/com/vonovak/AddCalendarEventModule.java
@@ -14,6 +14,7 @@ import com.facebook.react.bridge.*;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.TimeZone;
 
 public class AddCalendarEventModule extends ReactContextBaseJavaModule implements ActivityEventListener, LoaderManager.LoaderCallbacks {
 
@@ -42,6 +43,7 @@ public class AddCalendarEventModule extends ReactContextBaseJavaModule implement
 
     private static long getTimestamp(String dateAsString) throws ParseException {
         SimpleDateFormat datetimeFormatter = new SimpleDateFormat(DATE_PARSING_FORMAT);
+        datetimeFormatter.setTimeZone(TimeZone.getTimeZone("UTC"));
         return datetimeFormatter.parse(dateAsString).getTime();
     }
 

--- a/android/src/main/java/com/vonovak/AddCalendarEventModule.java
+++ b/android/src/main/java/com/vonovak/AddCalendarEventModule.java
@@ -19,7 +19,7 @@ public class AddCalendarEventModule extends ReactContextBaseJavaModule implement
 
     public final String ADD_EVENT_MODULE_NAME = "AddCalendarEvent";
     public final int ADD_EVENT_REQUEST_CODE = 11;
-    public static final String DATE_PARSING_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
+    public static final String DATE_PARSING_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
     private Promise promise;
     private Long eventPriorId;
 


### PR DESCRIPTION

I've applied [this suggestion](https://stackoverflow.com/questions/31090946/parsing-iso-8601-date-format-like-2015-06-27t131637-363z-in-java
) to fix the date parsing in Android ( Issue #9 )

I noticed the time was wrong and applied [this suggestion](https://stackoverflow.com/questions/19112357/java-simpledateformatyyyy-mm-ddthhmmssz-gives-timezone-as-ist) which forces the correct timezone.
