### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ or
 1.  `react-native link react-native-add-calendar-event`
 
 
-2.  add `NSCalendarsUsageDescription` key to your `Info.plist` file. The string value associated with the key will be used when asking user for calendar permission.
+2.  add `NSCalendarsUsageDescription` and `NSContactsUsageDescription` keys to your `Info.plist` file. The string value associated with the key will be used when asking user for calendar permission.
 
 3.  rebuild your project
 


### PR DESCRIPTION
Hello,

We had a crash on an iPhone X:

> abort | NSContactsUsageDescription | This app has crashed because it attempted to access privacy-sensitive data without a usage description. The app's Info.plist must contain an NSContactsUsageDescription key with a string value explaining to the user how the app uses this data.

This PR updates the documentation in order to let other users know that they should also include the NSContactsUsageDescription key.
 
Related: https://github.com/vonovak/react-native-add-calendar-event/issues/3