### PR TITLE
Docs: update manual iOS installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ see [StackOverflow answer](https://stackoverflow.com/questions/18425945/xcode-5-
 #### iOS
 
 1.  In XCode, in the project navigator, right click `Libraries` ➜ `Add Files to [your project's name]`
-2.  Go to `node_modules` ➜ `react-native-add-calendar-event` and add `libRNAddCalendarEvent.xcodeproj`
+2.  Go to `node_modules` ➜ `react-native-add-calendar-event` and add `RNAddCalendarEvent.xcodeproj`
 3.  In XCode, in the project navigator, select your project. Add `libRNAddCalendarEvent.a` to your project's `Build Phases` ➜ `Link Binary With Libraries`
 4.  Run your project (`Cmd+R`)<
 


### PR DESCRIPTION
Just `RNAddCalendarEvent.xcodeproj` is in the iOS folder, without `lib` as prefix