### PR TITLE
Allow to change navigation bar title color on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ navigationBarIOS: {
 }
 ```
 
-Please see the docs on [tintColor](https://developer.apple.com/documentation/uikit/uinavigationbar/1624937-tintcolor?language=objc), [barTintColor](https://developer.apple.com/documentation/uikit/uinavigationbar/1624931-bartintcolor?language=objc), [backgroundColor](https://developer.apple.com/documentation/uikit/uiview/1622591-backgroundcolor?language=objc), [translucent](https://developer.apple.com/documentation/uikit/uinavigationbar/1624928-translucent?language=objc)
+Please see the docs on [tintColor](https://developer.apple.com/documentation/uikit/uinavigationbar/1624937-tintcolor?language=objc), [barTintColor](https://developer.apple.com/documentation/uikit/uinavigationbar/1624931-bartintcolor?language=objc), [backgroundColor](https://developer.apple.com/documentation/uikit/uiview/1622591-backgroundcolor?language=objc), [translucent](https://developer.apple.com/documentation/uikit/uinavigationbar/1624928-translucent?language=objc), [titleTextAttributes](https://developer.apple.com/documentation/uikit/uinavigationbar/1624953-titletextattributes?language=objc) (NSForegroundColorAttributeName)
 
 ### Exported constants
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ navigationBarIOS: {
   barTintColor: string,
   backgroundColor: string,
   translucent: boolean,
+  titleColor: string,
 }
 ```
 

--- a/example/EventDemo/App.js
+++ b/example/EventDemo/App.js
@@ -67,6 +67,7 @@ export default class EventDemo extends Component {
       navigationBarIOS: {
         tintColor: 'orange',
         backgroundColor: 'green',
+        titleColor: 'blue',
       },
     };
 

--- a/index.js
+++ b/index.js
@@ -24,10 +24,11 @@ const processColorsIOS = config => {
   }
   const { navigationBarIOS } = config;
   if (navigationBarIOS) {
-    const { tintColor, backgroundColor, barTintColor } = navigationBarIOS;
+    const { tintColor, backgroundColor, barTintColor, titleColor } = navigationBarIOS;
     navigationBarIOS.tintColor = tintColor && processColor(tintColor);
     navigationBarIOS.backgroundColor = backgroundColor && processColor(backgroundColor);
     navigationBarIOS.barTintColor = barTintColor && processColor(barTintColor);
+    navigationBarIOS.titleColor = titleColor && processColor(titleColor);
   }
   return config;
 };

--- a/ios/AddCalendarEvent.m
+++ b/ios/AddCalendarEvent.m
@@ -212,7 +212,7 @@ RCT_EXPORT_METHOD(presentEventViewingDialog:(NSDictionary *)options resolver:(RC
         }
         if(navbarOptions[@"titleColor"]) {
             UIColor* titleColor = [RCTConvert UIColor:navbarOptions[@"titleColor"]];
-            navigationBar.titleTextAttributes =@{NSForegroundColorAttributeName: titleColor};
+            navigationBar.titleTextAttributes = @{NSForegroundColorAttributeName: titleColor};
         }
     }
 }

--- a/ios/AddCalendarEvent.m
+++ b/ios/AddCalendarEvent.m
@@ -210,6 +210,10 @@ RCT_EXPORT_METHOD(presentEventViewingDialog:(NSDictionary *)options resolver:(RC
         if (navbarOptions[@"barTintColor"]) {
             navigationBar.barTintColor = [RCTConvert UIColor:navbarOptions[@"barTintColor"]];
         }
+        if(navbarOptions[@"titleColor"]) {
+            UIColor* titleColor = [RCTConvert UIColor:navbarOptions[@"titleColor"]];
+            navigationBar.titleTextAttributes =@{NSForegroundColorAttributeName: titleColor};
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #49

This PR adds a new property `titleColor` that can be pass to `navigationBarIOS` to configure the color of the title.

It is also updating the docs and the example to make use of the new property