### PR TITLE
Fix typo in cancellation action flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ AddCalendarEvent.presentEventCreatingDialog(eventConfig)
     // handle success - receives an object with `calendarItemIdentifier` and `eventIdentifier` keys, both of type string.
     // These are two different identifiers on iOS.
     // On Android, where they are both equal and represent the event id, also strings.
-    // when { action: 'CANCELLED' } is returned, the dialog was dismissed
+    // when { action: 'CANCELED' } is returned, the dialog was dismissed
     console.warn(JSON.stringify(eventInfo));
   })
   .catch((error: string) => {

--- a/example/EventDemo/App.js
+++ b/example/EventDemo/App.js
@@ -76,7 +76,7 @@ export default class EventDemo extends Component {
         // handle success - receives an object with `calendarItemIdentifier` and `eventIdentifier` keys, both of type string.
         // These are two different identifiers on iOS.
         // On Android, where they are both equal and represent the event id, also strings.
-        // when { action: 'CANCELLED' } is returned, the dialog was dismissed
+        // when { action: 'CANCELED' } is returned, the dialog was dismissed
         console.warn(JSON.stringify(eventInfo));
       })
       .catch((error: string) => {


### PR DESCRIPTION
The ReadME lists the cancellation action flag as `CANCELLED`, but the actual flag has a single `L`.

This PR fixes this.