### PR TITLE
Possibility to add an alert for iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,10 @@ eventConfig object:
 The dates passed to this module are strings. If you use moment, you may get the right format via `momentInUTC.format('YYYY-MM-DDTHH:mm:ss.SSS[Z]')` the string may look eg. like this: `'2017-09-25T08:00:00.000Z'`.
 
 For the alert field, here is the specs : 
-- If you set alert: "0" => will add an alert at the startDate.
-- If you set alert: "1" => will add an alert 5 minutes before the startDate.
-- If you set alert: "2" => will add an alert 30 minutes before the startDate.
-- If you set alert: "3" => will add an alert 60 minutes before the startDate.
+- If you set `alert: "0"` => will add an alert at the startDate.
+- If you set `alert: "1"` => will add an alert 5 minutes before the startDate.
+- If you set `alert: "2"` => will add an alert 30 minutes before the startDate.
+- If you set `alert: "3"` => will add an alert 60 minutes before the startDate.
 - If alert is not set in the eventConfig, no alert will be set. 
 
 More options can be easily added, PRs are welcome!

--- a/README.md
+++ b/README.md
@@ -72,11 +72,11 @@ eventConfig object:
 The dates passed to this module are strings. If you use moment, you may get the right format via `momentInUTC.format('YYYY-MM-DDTHH:mm:ss.SSS[Z]')` the string may look eg. like this: `'2017-09-25T08:00:00.000Z'`.
 
 For the alert field, here is the specs : 
-If you set alert: "0" => will add an alert at the startDate.
-If you set alert: "1" => will add an alert 5 minutes before the startDate.
-If you set alert: "2" => will add an alert 30 minutes before the startDate.
-If you set alert: "3" => will add an alert 60 minutes before the startDate.
-If alert is not set in the eventConfig, no alert will be set. 
+- If you set alert: "0" => will add an alert at the startDate.
+- If you set alert: "1" => will add an alert 5 minutes before the startDate.
+- If you set alert: "2" => will add an alert 30 minutes before the startDate.
+- If you set alert: "3" => will add an alert 60 minutes before the startDate.
+- If alert is not set in the eventConfig, no alert will be set. 
 
 More options can be easily added, PRs are welcome!
 

--- a/README.md
+++ b/README.md
@@ -67,8 +67,16 @@ eventConfig object:
 | allDay    | boolean |                                                                     |
 | url       | String  | iOS only                                                            |
 | notes     | String  | The notes (iOS) or description (Android) associated with the event. |
+| alert     | String  | Allow the user to set an alert, could be "0", "1", "2", "3", or none|
 
 The dates passed to this module are strings. If you use moment, you may get the right format via `momentInUTC.format('YYYY-MM-DDTHH:mm:ss.SSS[Z]')` the string may look eg. like this: `'2017-09-25T08:00:00.000Z'`.
+
+For the alert field, here is the specs : 
+If you set alert: "0" => will add an alert at the startDate.
+If you set alert: "1" => will add an alert 5 minutes before the startDate.
+If you set alert: "2" => will add an alert 30 minutes before the startDate.
+If you set alert: "3" => will add an alert 60 minutes before the startDate.
+If alert is not set in the eventConfig, no alert will be set. 
 
 More options can be easily added, PRs are welcome!
 

--- a/example/EventDemo/App.js
+++ b/example/EventDemo/App.js
@@ -64,6 +64,7 @@ export default class EventDemo extends Component {
       startDate: utcDateToString(startDateUTC),
       endDate: utcDateToString(moment.utc(startDateUTC).add(1, 'hours')),
       notes: 'tasty!',
+      alert: "1", //it's gonna add an alarm 5 minutes before
       navigationBarIOS: {
         tintColor: 'orange',
         backgroundColor: 'green',

--- a/index.d.ts
+++ b/index.d.ts
@@ -28,6 +28,15 @@ declare module "react-native-add-calendar-event" {
      */
     notes?: string;
     navigationBarIOS?: NavigationBarIOS;
+    /*
+    * Alert string, could be "0", "1", "2" or "3"
+    * 0 => set an alarm at the original startDate
+    * 1 => set an alarm 5 minutes before startDate
+    * 2 => set an alarm 30 minutes before startDate
+    * 3 => set an alarm 60 minutes before startDate
+    * if no alert is set in the config, then no alert is set on the reminder
+    */
+   alert?: string;
   }
 
   /**

--- a/ios/AddCalendarEvent.m
+++ b/ios/AddCalendarEvent.m
@@ -53,6 +53,7 @@ static NSString *const _endDate = @"endDate";
 static NSString *const _notes = @"notes";
 static NSString *const _url = @"url";
 static NSString *const _allDay = @"allDay";
+static NSString *const _alert = @"alert";
 
 static NSString *const MODULE_NAME= @"AddCalendarEvent";
 
@@ -271,6 +272,33 @@ RCT_EXPORT_METHOD(presentEventEditingDialog:(NSDictionary *)options resolver:(RC
     }
     if (options[_allDay]) {
         event.allDay = [RCTConvert BOOL:options[_allDay]];
+    }
+    if (options[_alert]) {
+        NSDate *originalDate =  [RCTConvert NSDate:options[_startDate]];
+
+        if ([[RCTConvert NSString:options[_alert]] caseInsensitiveCompare:@"0"] == NSOrderedSame) 
+        { 
+            EKAlarm * alarm = [EKAlarm alarmWithAbsoluteDate:originalDate];
+            event.alarms = @[alarm];
+        }
+        if ([[RCTConvert NSString:options[_alert]] caseInsensitiveCompare:@"1"] == NSOrderedSame) 
+        { 
+            NSDate *alertReminder = [originalDate dateByAddingTimeInterval:-60*5]; 
+            EKAlarm * alarm = [EKAlarm alarmWithAbsoluteDate:alertReminder];
+            event.alarms = @[alarm];
+        }
+        if ([[RCTConvert NSString:options[_alert]] caseInsensitiveCompare:@"2"] == NSOrderedSame) 
+        {
+            NSDate *alertReminder = [originalDate dateByAddingTimeInterval:-60*30]; 
+            EKAlarm * alarm = [EKAlarm alarmWithAbsoluteDate:alertReminder];
+            event.alarms = @[alarm];
+        }
+        if ([[RCTConvert NSString:options[_alert]] caseInsensitiveCompare:@"3"] == NSOrderedSame) 
+        { 
+            NSDate *alertReminder = [originalDate dateByAddingTimeInterval:-60*60]; 
+            EKAlarm * alarm = [EKAlarm alarmWithAbsoluteDate:alertReminder];
+            event.alarms = @[alarm];
+        }
     }
     return event;
 }


### PR DESCRIPTION
I added the possibility to set an alarm since there was none by default. It works for iOS, because in Android, it use the native calendar, and users already got reminder 5 or 10 minutes before any events on their calendar, but not on iOS if no alarm is set.

I just added a field alert, and manage the differences in `ios/AddCalendarEvent.m` and succeed to manage it thanks to `EKAlarm`.

You just have to pass a field `alert` in the eventConfig. 
- 0 will set an alarm equal to startDate.
- 1 will set an alarm 5 minutes before startDate.
- 2 will set an alarm 30 minutes before startDate.
- 3 will set an alarm 60 minutes before startDate.