### PR TITLE
Update .npmignore fixes #71

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,41 @@
-node_modules
+# Examples
 example
+
+# Configs
+.gitignore
+.gitattributes
+.npmignore
+yarn.lock
+
+# Android/IntelliJ
+build/
+.idea
+.gradle
+local.properties
+*.iml
+
+# Xcode
+build/
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata
+*.xccheckout
+*.moved-aside
+DerivedData
+*.hmap
+*.ipa
+*.xcuserstate
+project.xcworkspace
+
+# node.js
+node_modules/
+npm-debug.log
+yarn-error.log
+yarn.lock
+package-lock.json


### PR DESCRIPTION
It seems that a bunch of unnecessary files are released with the npm package, that cause issues, like #71. I copied some ignores from the .gitignore to the .npmignore. 

Note:
> If a project has both an .npmignore and .gitignore file, npm will only use the .npmignore file.
> — [source](https://stackoverflow.com/questions/24942161/does-npm-ignore-files-listed-in-gitignore)