### PR TITLE
Added support for Outlook (Edited Android Intent type)

### DIFF
--- a/android/src/main/java/com/vonovak/AddCalendarEventModule.java
+++ b/android/src/main/java/com/vonovak/AddCalendarEventModule.java
@@ -86,7 +86,7 @@ public class AddCalendarEventModule extends ReactContextBaseJavaModule implement
         try {
             setPriorEventId(getCurrentActivity());
 
-            final Intent calendarIntent = new Intent(Intent.ACTION_EDIT);
+            final Intent calendarIntent = new Intent(Intent.ACTION_INSERT);
             calendarIntent
                     .setType("vnd.android.cursor.item/event")
                     .putExtra("title", config.getString("title"));


### PR DESCRIPTION
Based on https://developer.android.com/guide/topics/providers/calendar-provider#intent-edit
The proper way to add event is to use `ACTION_INSERT`. It closes #63 
Also, in android docs said that we dont need `WRITE_CALENDAR` permission in manifest. But without it, library doesn't work for me. Do you have any thoughts about this permissions @vonovak ?