### PR TITLE
fix podspec for XCode 12

### DIFF
--- a/react-native-add-calendar-event.podspec
+++ b/react-native-add-calendar-event.podspec
@@ -13,5 +13,5 @@ Pod::Spec.new do |s|
 
   s.source_files  = 'ios/*.{h,m}'
 
-  s.dependency 'React'
+  s.dependency 'React-Core'
 end


### PR DESCRIPTION
Xcode 12 won't build if a module depends on React instead of React-Core. 

Reference: https://github.com/facebook/react-native/issues/29633#issuecomment-694187116
